### PR TITLE
Support refs to DOM nodes [#8]

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,11 @@ To set the default value to certain enum option, use good ol' CSS:
 }
 ```
 
+### Refs to DOM nodes
+Passing ref to component will give a ref to the decss wrapper, not to DOM node. So it's not possible to call DOM methods, like focus on that wrapper. To get a ref to wrapped DOM node, pass innerRef prop.
+
+> Note: innerRef only supports callback refs (i.e. ref={comp => this.bla = comp}), string refs (i.e. ref="bla") won't work.
+
 ## Related
 
 - [styled-components]: the source of inspiration.

--- a/index.js
+++ b/index.js
@@ -71,7 +71,6 @@ function createComponent (h, componentObj, componentName, defaultProps) {
     var compoundProps = Object.assign({ className: className }, tagProps)
     if (props.innerRef) {
       compoundProps.ref = props.innerRef
-      delete compoundProps.innerRef
     }
     var helperArgs = [tag, compoundProps].concat(
       (props && props.children) || []

--- a/index.js
+++ b/index.js
@@ -66,9 +66,13 @@ function createComponent (h, componentObj, componentName, defaultProps) {
     )
     var tagProps = without(
       props,
-      ['tag', 'children'].concat(Object.keys(componentObj.modifiers))
+      ['tag', 'children', 'innerRef'].concat(Object.keys(componentObj.modifiers))
     )
     var compoundProps = Object.assign({ className: className }, tagProps)
+    if (props.innerRef) {
+      compoundProps.ref = props.innerRef
+      delete compoundProps.innerRef
+    }
     var helperArgs = [tag, compoundProps].concat(
       (props && props.children) || []
     )

--- a/test.js
+++ b/test.js
@@ -101,3 +101,15 @@ test('it passes extra props to the tag element', t => {
   const args = Component({ children: 42, a: 1, b: 2 })
   t.deepEqual(args, ['div', { className: 'component-class', a: 1, b: 2 }, 42])
 })
+
+
+test('it passes refs callback to the tag element', t => {
+  const refsCallback = () => {}
+  const { Component } = decss(
+    passArgs, {
+      Component: 'component-class'
+    }
+  )
+  const args = Component({ children: 42, innerRef: refsCallback })
+  t.deepEqual(args, ['div', { className: 'component-class', ref: refsCallback }, 42])
+})


### PR DESCRIPTION
I propose the implementation like in **styled-components**: use `innerRef` props to pass it to DOM nodes.

See **styled-components** discussion: https://github.com/styled-components/styled-components/issues/102